### PR TITLE
fix(deployment): correct Docker deployment and configuration paths

### DIFF
--- a/.github/workflows/release-adhoc.yml
+++ b/.github/workflows/release-adhoc.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: 'latest'
       services:
-        description: 'Comma-separated list of services to build (executor,miner,validator,public-api) or "all"'
+        description: 'Comma-separated list of services to build (executor,miner,validator) or "all"'
         required: true
         default: 'all'
 
@@ -27,7 +27,7 @@ jobs:
         id: parse
         run: |
           if [ "${{ github.event.inputs.services }}" = "all" ]; then
-            echo 'services=["executor", "miner", "validator", "public-api"]' >> $GITHUB_OUTPUT
+            echo 'services=["executor", "miner", "validator"]' >> $GITHUB_OUTPUT
           else
             # Convert comma-separated to JSON array
             services=$(echo "${{ github.event.inputs.services }}" | sed 's/,/", "/g' | sed 's/^/["/' | sed 's/$/"]/')
@@ -57,15 +57,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.service }}
-          tags: |
-            type=raw,value=${{ github.event.inputs.tag }}
-            type=sha,prefix={{branch}}-
-
       # Copy veritas binaries for validator
       - name: Copy veritas binaries
         if: matrix.service == 'validator'
@@ -73,18 +64,17 @@ jobs:
           cp bin/executor-binary/executor-binary ./executor-binary
           cp bin/validator-binary/validator-binary ./validator-binary
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./scripts/${{ matrix.service }}/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            BUILD_MODE=release
-            VERSION=${{ github.event.inputs.tag }}
-            BITTENSOR_NETWORK=finney
+      - name: Build Docker image
+        env:
+          BITTENSOR_NETWORK: finney
+        run: |
+          ./scripts/${{ matrix.service }}/build.sh \
+            --image-name ghcr.io/tplr-ai/basilica/${{ matrix.service }} \
+            --image-tag ${{ github.event.inputs.tag }}
+
+      - name: Push Docker image
+        run: |
+          ./scripts/${{ matrix.service }}/push.sh \
+            --source-image ghcr.io/tplr-ai/basilica/${{ matrix.service }} \
+            --target-image ghcr.io/tplr-ai/basilica/${{ matrix.service }} \
+            --tag ${{ github.event.inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        service: [executor, miner, validator, public-api]
+        service: [executor, miner, validator]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -149,18 +149,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.service }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
+      - name: Extract version tag
+        id: version
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       # Copy veritas binaries for validator
       - name: Copy veritas binaries
@@ -169,18 +160,17 @@ jobs:
           cp bin/executor-binary/executor-binary ./executor-binary
           cp bin/validator-binary/validator-binary ./validator-binary
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./scripts/${{ matrix.service }}/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            BUILD_MODE=release
-            VERSION=${{ needs.create-release.outputs.version }}
-            BITTENSOR_NETWORK=finney
+      - name: Build Docker image
+        env:
+          BITTENSOR_NETWORK: finney
+        run: |
+          ./scripts/${{ matrix.service }}/build.sh \
+            --image-name ghcr.io/tplr-ai/basilica/${{ matrix.service }} \
+            --image-tag ${{ steps.version.outputs.tag }}
+
+      - name: Push Docker image
+        run: |
+          ./scripts/${{ matrix.service }}/push.sh \
+            --source-image ghcr.io/tplr-ai/basilica/${{ matrix.service }} \
+            --target-image ghcr.io/tplr-ai/basilica/${{ matrix.service }} \
+            --tag ${{ steps.version.outputs.tag }}

--- a/config/validator.correct.toml
+++ b/config/validator.correct.toml
@@ -5,9 +5,9 @@ run_migrations = true
 
 [server]
 host = "0.0.0.0"
-port = 8081
+port = 8080
 advertised_host = "160.202.129.15"
-advertised_port = 8081
+advertised_port = 8080
 advertised_tls = false
 max_connections = 1000
 request_timeout = { secs = 30 }
@@ -15,11 +15,11 @@ request_timeout = { secs = 30 }
 [bittensor]
 wallet_name = "test_validator"
 hotkey_name = "default"
-network = "test"
-netuid = 387
-chain_endpoint = "wss://test.finney.opentensor.ai:443"
+network = "finney"
+netuid = 39
+chain_endpoint = "wss://entrypoint-finney.opentensor.ai:443"
 weight_interval_secs = 300
-axon_port = 8081
+axon_port = 8080
 external_ip = "160.202.129.15"
 
 [verification]
@@ -29,7 +29,7 @@ verification_interval = { secs = 600 }
 challenge_timeout = { secs = 120 }
 retry_attempts = 3
 retry_delay = { secs = 5 }
-netuid = 387
+netuid = 39
 use_dynamic_discovery = true
 discovery_timeout = { secs = 30 }
 fallback_to_static = true

--- a/config/validator.toml.example
+++ b/config/validator.toml.example
@@ -5,9 +5,9 @@ run_migrations = true
 
 [server]
 host = "0.0.0.0"
-port = 8081
+port = 8080
 advertised_host = "YOUR_PUBLIC_IP_HERE"
-advertised_port = 8081
+advertised_port = 8080
 advertised_tls = false
 max_connections = 1000
 request_timeout = { secs = 30 }
@@ -19,7 +19,7 @@ network = "finney"  # Options: "finney", "test", or "local"
 netuid = 39         # Use 387 for test network
 chain_endpoint = "wss://entrypoint-finney.opentensor.ai:443"  # Auto-detected based on network
 weight_interval_secs = 300
-axon_port = 8081
+axon_port = 8080
 external_ip = "YOUR_PUBLIC_IP_HERE"
 
 [verification]
@@ -103,7 +103,7 @@ ssh_retry_delay = { secs = 2, nanos = 0 }
 
 [emission]
 # Percentage of total emissions to burn (0.0-100.0)
-burn_percentage = 5.0
+burn_percentage = 95.0
 
 # UID to receive burn allocation
 burn_uid = 204
@@ -111,6 +111,10 @@ burn_uid = 204
 # Blocks between weight setting operations
 # 360 blocks = ~1 hour on Bittensor (12 seconds per block)
 weight_set_interval_blocks = 360
+
+# Minimum number of miners required
+# per GPU category to receive allocation
+min_miners_per_category = 1
 
 # Version key for weight setting operations
 # This prevents replay attacks by incrementing with each weight set

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,14 +35,15 @@ This is the fastest way to get started with production-ready deployment.
 cd scripts/validator
 
 # 2. Prepare configuration
-cp ../../config/validator.correct.toml ../../config/validator.toml
-# Edit config/validator.toml with your settings:
+cp ../../config/validator.correct.toml /opt/basilica/config/validator.toml
+# Edit /opt/basilica/config/validator.toml with your settings:
 # - wallet_name and hotkey_name
 # - external_ip (your public IP)
 # - network ("finney" for mainnet, "test" for testnet)
 
-# 3. Ensure wallet exists
+# 3. Ensure wallet exists and create directories
 ls ~/.bittensor/wallets/your_wallet/hotkeys/
+mkdir -p /opt/basilica/config /opt/basilica/data /var/log/basilica
 
 # 4. Deploy with auto-updates and monitoring
 docker compose -f compose.prod.yml up -d
@@ -58,14 +59,15 @@ docker logs basilica-validator
 cd scripts/miner
 
 # 2. Prepare configuration
-cp ../../config/miner.correct.toml ../../config/miner.toml
-# Edit config/miner.toml with your settings:
+cp ../../config/miner.correct.toml /opt/basilica/config/miner.toml
+# Edit /opt/basilica/config/miner.toml with your settings:
 # - wallet_name and hotkey_name
 # - external_ip (your public IP)
 # - executor fleet configuration
 # - network ("finney" for mainnet, "test" for testnet)
 
-# 3. Deploy with auto-updates and monitoring
+# 3. Create directories and deploy
+mkdir -p /opt/basilica/config /opt/basilica/data /var/log/basilica
 docker compose -f compose.prod.yml up -d
 
 # 4. Check status
@@ -79,12 +81,13 @@ docker logs basilica-miner
 cd scripts/executor
 
 # 2. Prepare configuration
-cp ../../config/executor.correct.toml ../../config/executor.toml
-# Edit config/executor.toml with your settings:
+cp ../../config/executor.correct.toml /opt/basilica/config/executor.toml
+# Edit /opt/basilica/config/executor.toml with your settings:
 # - managing_miner_hotkey (your miner's hotkey)
 # - advertised_host (your public IP)
 
-# 3. Deploy with GPU access and auto-updates
+# 3. Create directories and deploy with GPU access
+mkdir -p /opt/basilica/config /opt/basilica/data /var/log/basilica
 docker compose -f compose.prod.yml up -d
 
 # 4. Check status
@@ -96,15 +99,10 @@ docker logs basilica-executor
 Deploy to remote servers using the automated deployment script:
 
 ```bash
-# Deploy all services to different servers
-./scripts/deploy.sh -s all \
-  -v user@validator-server:port \
-  -m user@miner-server:port \
-  -e user@executor-server:port \
-  -w -c
-
-# Or deploy individual services
-./scripts/deploy.sh -s validator -v user@server:port -w
+# Deploy individual services to remote servers
+./scripts/validator/deploy.sh -s user@validator-server:port -w --health-check
+./scripts/miner/deploy.sh -s user@miner-server:port -w --health-check
+./scripts/executor/deploy.sh -s user@executor-server:port --health-check
 ```
 
 See [BASILICA-DEPLOYMENT-GUIDE.md](../BASILICA-DEPLOYMENT-GUIDE.md) for detailed deployment instructions.
@@ -126,9 +124,9 @@ cp config/executor.correct.toml config/executor.toml
 # Edit configurations as needed
 
 # 3. Run services
-./validator --config config/validator.toml
+./validator --config config/validator.toml start
 ./miner --config config/miner.toml
-./executor --config config/executor.toml
+./executor --server --config config/executor.toml
 ```
 
 ## Monitoring Your Deployment
@@ -147,7 +145,7 @@ docker logs basilica-executor
 # Check health endpoints
 curl http://localhost:8080/health  # validator
 curl http://localhost:8080/health  # miner
-curl http://localhost:8080/health  # executor
+curl http://localhost:50052/health  # executor
 ```
 
 ### Access Monitoring Dashboard

--- a/scripts/executor/compose.prod.yml
+++ b/scripts/executor/compose.prod.yml
@@ -9,29 +9,35 @@ services:
     privileged: true
 
     environment:
-      - RUST_LOG=info
+      - RUST_LOG=debug
       - RUST_BACKTRACE=1
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ../../config/executor.toml:/app/executor.toml:ro
-      - executor-data:/app/data
-      - /dev:/dev:rw
+      - /opt/basilica/config/executor.toml:/opt/basilica/config/executor.toml:ro
+      - /opt/basilica/data:/opt/basilica/data:rw
+      - ~/.ssh:/opt/basilica/keys:ro
+      - /var/log/basilica:/var/log/basilica:rw
 
     ports:
-      - "50052:50052"   # gRPC server
-      - "8080:8080"     # Metrics
-      - "22222:22"      # SSH for validator
+      - "50051:50051"   # gRPC server (from config server.port)
+      - "50052:50052"   # Health port (from config health.port)
+      - "9090:9090"     # Metrics port (from config metrics.prometheus.port)
+      - "22:22"         # SSH for validator (from config validator.ssh_port)
+
+    dns:
+      - 1.1.1.1
+      - 1.0.0.1
 
     networks:
       - basilica_network
 
-    command: ["--config", "/app/executor.toml"]
+    command: ["--server", "--config", "/opt/basilica/config/executor.toml"]
 
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:50052/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -53,13 +59,13 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - WATCHTOWER_CLEANUP=true
-      - WATCHTOWER_POLL_INTERVAL=300
+      - WATCHTOWER_POLL_INTERVAL=60
       - WATCHTOWER_LABEL_ENABLE=true
-    command: --label-enable --cleanup --interval 300
+    dns:
+      - 1.1.1.1
+      - 1.0.0.1
+    command: --label-enable --cleanup --interval 60
 
 networks:
   basilica_network:
     driver: bridge
-
-volumes:
-  executor-data:

--- a/scripts/executor/push.sh
+++ b/scripts/executor/push.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SOURCE_IMAGE="basilica/executor"
+TARGET_IMAGE="ghcr.io/tplr-ai/basilica/executor"
+IMAGE_TAG="latest"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --source-image)
+            SOURCE_IMAGE="$2"
+            shift 2
+            ;;
+        --target-image)
+            TARGET_IMAGE="$2"
+            shift 2
+            ;;
+        --tag)
+            IMAGE_TAG="$2"
+            shift 2
+            ;;
+        --help)
+            echo "Usage: $0 [--source-image SOURCE] [--target-image TARGET] [--tag TAG]"
+            echo ""
+            echo "Options:"
+            echo "  --source-image SOURCE     Source Docker image (default: basilica/executor)"
+            echo "  --target-image TARGET     Target Docker image (default: ghcr.io/tplr-ai/basilica/executor)"
+            echo "  --tag TAG                 Image tag (default: latest)"
+            echo "  --help                    Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+SOURCE_IMAGE_FULL="${SOURCE_IMAGE}:${IMAGE_TAG}"
+TARGET_IMAGE_FULL="${TARGET_IMAGE}:${IMAGE_TAG}"
+
+echo "Tagging and pushing executor image..."
+echo "  Source: $SOURCE_IMAGE_FULL"
+echo "  Target: $TARGET_IMAGE_FULL"
+
+# Check if source image exists
+if ! docker images --format "table {{.Repository}}:{{.Tag}}" | grep -q "^${SOURCE_IMAGE_FULL}$"; then
+    echo "Error: Source image $SOURCE_IMAGE_FULL not found"
+    echo "Please build the image first using: ./scripts/executor/build.sh"
+    exit 1
+fi
+
+# Tag the image
+echo "Tagging image..."
+docker tag "$SOURCE_IMAGE_FULL" "$TARGET_IMAGE_FULL"
+
+# Push the image
+echo "Pushing image to registry..."
+docker push "$TARGET_IMAGE_FULL"
+
+echo "Successfully pushed $TARGET_IMAGE_FULL"

--- a/scripts/miner/compose.prod.yml
+++ b/scripts/miner/compose.prod.yml
@@ -7,24 +7,28 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
 
     environment:
-      - RUST_LOG=info
+      - RUST_LOG=debug
       - RUST_BACKTRACE=1
 
     volumes:
-      - ../../config/miner.toml:/app/miner.toml:ro
-      - miner-data:/app/data
-      - ~/.bittensor:/home/basilica/.bittensor:rw
+      - /opt/basilica/config/miner.toml:/opt/basilica/config/miner.toml:ro
+      - /opt/basilica/data:/opt/basilica/data:rw
+      - ~/.ssh:/opt/basilica/keys:ro
+      - ~/.bittensor:/root/.bittensor:rw
       - /var/log/basilica:/var/log/basilica:rw
 
     ports:
-      - "50051:50051"   # gRPC server
-      - "8091:8091"     # Bittensor axon port
-      - "8080:8080"     # Metrics endpoint
+      - "8080:8080"     # Server/API port (from config server.port)
+      - "9090:9090"     # Metrics port (from config metrics.prometheus.port)
+
+    dns:
+      - 1.1.1.1
+      - 1.0.0.1
 
     networks:
       - basilica_network
 
-    command: ["--config", "/app/miner.toml"]
+    command: ["--config", "/opt/basilica/config/miner.toml"]
 
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
@@ -41,13 +45,13 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - WATCHTOWER_CLEANUP=true
-      - WATCHTOWER_POLL_INTERVAL=300
+      - WATCHTOWER_POLL_INTERVAL=60
       - WATCHTOWER_LABEL_ENABLE=true
-    command: --label-enable --cleanup --interval 300
+    dns:
+      - 1.1.1.1
+      - 1.0.0.1
+    command: --label-enable --cleanup --interval 60
 
 networks:
   basilica_network:
     driver: bridge
-
-volumes:
-  miner-data:

--- a/scripts/miner/push.sh
+++ b/scripts/miner/push.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SOURCE_IMAGE="basilica/miner"
+TARGET_IMAGE="ghcr.io/tplr-ai/basilica/miner"
+IMAGE_TAG="latest"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --source-image)
+            SOURCE_IMAGE="$2"
+            shift 2
+            ;;
+        --target-image)
+            TARGET_IMAGE="$2"
+            shift 2
+            ;;
+        --tag)
+            IMAGE_TAG="$2"
+            shift 2
+            ;;
+        --help)
+            echo "Usage: $0 [--source-image SOURCE] [--target-image TARGET] [--tag TAG]"
+            echo ""
+            echo "Options:"
+            echo "  --source-image SOURCE     Source Docker image (default: basilica/miner)"
+            echo "  --target-image TARGET     Target Docker image (default: ghcr.io/tplr-ai/basilica/miner)"
+            echo "  --tag TAG                 Image tag (default: latest)"
+            echo "  --help                    Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+SOURCE_IMAGE_FULL="${SOURCE_IMAGE}:${IMAGE_TAG}"
+TARGET_IMAGE_FULL="${TARGET_IMAGE}:${IMAGE_TAG}"
+
+echo "Tagging and pushing miner image..."
+echo "  Source: $SOURCE_IMAGE_FULL"
+echo "  Target: $TARGET_IMAGE_FULL"
+
+# Check if source image exists
+if ! docker images --format "table {{.Repository}}:{{.Tag}}" | grep -q "^${SOURCE_IMAGE_FULL}$"; then
+    echo "Error: Source image $SOURCE_IMAGE_FULL not found"
+    echo "Please build the image first using: ./scripts/miner/build.sh"
+    exit 1
+fi
+
+# Tag the image
+echo "Tagging image..."
+docker tag "$SOURCE_IMAGE_FULL" "$TARGET_IMAGE_FULL"
+
+# Push the image
+echo "Pushing image to registry..."
+docker push "$TARGET_IMAGE_FULL"
+
+echo "Successfully pushed $TARGET_IMAGE_FULL"


### PR DESCRIPTION
* Replace Docker build-push-action with custom build/push scripts for better control
* Standardize configuration paths to /opt/basilica/config/ across all services
* Update port mappings in documentation and Docker compose files
* Remove public-api service references from CI workflows
* Fix validator port configuration from 8081 to 8080 for consistency
* Add DNS configuration and faster update intervals to production compose files
* Update burn percentage to 95% and add min_miners_per_category in validator config
* Improve Docker volume mounts and SSH key handling for production deployments
* Add executable push.sh scripts for executor and miner components
* Update documentation to reflect new deployment patterns and standardized paths