### PR TITLE
feat(validator): implement emission metrics persistence

### DIFF
--- a/crates/validator/src/config/main_config.rs
+++ b/crates/validator/src/config/main_config.rs
@@ -70,6 +70,10 @@ pub struct ValidatorConfig {
     /// Emission allocation configuration
     #[serde(default)]
     pub emission: super::emission::EmissionConfig,
+
+    /// Database cleanup configuration
+    #[serde(default)]
+    pub cleanup: crate::persistence::cleanup_task::CleanupConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -395,6 +399,7 @@ impl Default for ValidatorConfig {
             },
             ssh_session: SshSessionConfig::default(),
             emission: super::emission::EmissionConfig::default(),
+            cleanup: crate::persistence::cleanup_task::CleanupConfig::default(),
         }
     }
 }

--- a/crates/validator/src/persistence/cleanup_task.rs
+++ b/crates/validator/src/persistence/cleanup_task.rs
@@ -7,10 +7,10 @@ use std::sync::Arc;
 use tokio::time::{interval, Duration};
 use tracing::{error, info, warn};
 
-use crate::persistence::GpuProfileRepository;
+use crate::persistence::gpu_profile_repository::GpuProfileRepository;
 
 /// Configuration for cleanup tasks
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CleanupConfig {
     /// How often to run cleanup (in hours)
     pub run_interval_hours: u64,

--- a/crates/validator/src/persistence/mod.rs
+++ b/crates/validator/src/persistence/mod.rs
@@ -1,3 +1,4 @@
+pub mod cleanup_task;
 pub mod entities;
 pub mod gpu_profile_repository;
 pub mod simple_persistence;


### PR DESCRIPTION
* Add database persistence for emission metrics after each weight set
* Store per-category distribution data including miner count, total weight, and average scores
* Record individual weight allocations with miner scores and category totals
* Track burn allocations separately with dedicated BURN category entries
* Integrate GPU profile repository into weight setter for category resolution
* Add configurable database cleanup task to validator service lifecycle
* Enable automatic pruning of old emission data based on retention settings
* Fix import path for GpuProfileRepository in cleanup task module
* Add serde traits to CleanupConfig for TOML configuration support
* Export cleanup_task module in persistence mod.rs for service access
* Link weight allocations to emission metrics via foreign key relationship
* Initialize cleanup service during validator startup when enabled in config