### PR TITLE
feat(miner): implement stake-based validator assignment strategy

### DIFF
--- a/config/miner.correct.toml
+++ b/config/miner.correct.toml
@@ -164,7 +164,10 @@ secs = 2
 nanos = 0
 
 [validator_assignment]
-strategy = "round_robin"
+enabled = true
+strategy = "highest_stake"
+min_stake_threshold = 6000.0
+validator_hotkey = "5G3qVaXzKMPDm5AJ3dpzbpUC27kpccBvDwzSWXrq8M6qMmbC"
 
 [advertised_addresses]
 

--- a/config/miner.prod.toml
+++ b/config/miner.prod.toml
@@ -178,7 +178,10 @@ secs = 2
 nanos = 0
 
 [validator_assignment]
-strategy = "round_robin"
+enabled = true
+strategy = "highest_stake"
+min_stake_threshold = 6000.0
+validator_hotkey = "5G3qVaXzKMPDm5AJ3dpzbpUC27kpccBvDwzSWXrq8M6qMmbC"
 
 [advertised_addresses]
 # These should match your external IP and ports

--- a/config/miner.toml.example
+++ b/config/miner.toml.example
@@ -166,7 +166,10 @@ secs = 2
 nanos = 0
 
 [validator_assignment]
-strategy = "round_robin"
+enabled = true
+strategy = "highest_stake"
+min_stake_threshold = 6000.0
+validator_hotkey = "5G3qVaXzKMPDm5AJ3dpzbpUC27kpccBvDwzSWXrq8M6qMmbC"
 
 [advertised_addresses]
 grpc_endpoint = "http://YOUR_PUBLIC_IP_HERE:8080"

--- a/crates/miner/src/config.rs
+++ b/crates/miner/src/config.rs
@@ -310,7 +310,7 @@ pub struct ExecutorSshConfig {
     #[serde(default = "default_ssh_connection_timeout")]
     pub ssh_connection_timeout: Duration,
 
-    /// SSH command execution timeout  
+    /// SSH command execution timeout
     #[serde(default = "default_ssh_command_timeout")]
     pub ssh_command_timeout: Duration,
 
@@ -346,15 +346,25 @@ pub struct ValidatorAssignmentConfig {
     #[serde(default = "default_enable_validator_assignment")]
     pub enabled: bool,
 
-    /// Assignment strategy to use (only "round_robin" supported)
+    /// Assignment strategy to use ("highest_stake", "round_robin", etc.)
+    #[serde(default = "default_strategy")]
     pub strategy: String,
+
+    /// Minimum stake threshold in TAO for validator eligibility
+    #[serde(default = "default_min_stake_threshold")]
+    pub min_stake_threshold: f64,
+
+    /// Specific validator hotkey to assign executors to (for highest_stake strategy)
+    pub validator_hotkey: Option<String>,
 }
 
 impl Default for ValidatorAssignmentConfig {
     fn default() -> Self {
         Self {
             enabled: default_enable_validator_assignment(),
-            strategy: "round_robin".to_string(),
+            strategy: default_strategy(),
+            min_stake_threshold: default_min_stake_threshold(),
+            validator_hotkey: None,
         }
     }
 }
@@ -439,7 +449,15 @@ fn default_ssh_retry_delay() -> Duration {
 }
 
 fn default_enable_validator_assignment() -> bool {
-    false
+    true
+}
+
+fn default_strategy() -> String {
+    "highest_stake".to_string()
+}
+
+fn default_min_stake_threshold() -> f64 {
+    6000.0 // 6000 TAO
 }
 
 impl Default for ExecutorSshConfig {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,10 +27,10 @@ The miner acts as a fleet manager for GPU resources:
 - **Executor Fleet Manager**: Orchestrates multiple GPU executor machines
 - **Axon Server**: Serves compute requests on the Bittensor network
 - **gRPC Client**: Manages communication with executors
-- **Assignment Manager**: Routes computational tasks to appropriate executors
+- **Assignment Manager**: Routes validation tasks to the executors based on strategies
 - **SSH Session Management**: Handles validator access and session orchestration
-- **Stake Monitor**: Tracks stake levels and maintains service quality
-- **SQLite Storage**: Persists executor assignments and registration data
+- **Stake Monitor**: Tracks validator stake levels for assignment decisions and service quality
+- **SQLite Storage**: Persists executor assignments, validator stakes, and registration data
 
 ### 3. Executor
 

--- a/docs/miner.md
+++ b/docs/miner.md
@@ -107,7 +107,39 @@ enabled = true
 [metrics.prometheus]
 enabled = true
 port = 9091
+
+[validator_assignment]
+enabled = true
+strategy = "highest_stake"  # Options: "highest_stake", "round_robin"
+min_stake_threshold = 6000.0  # Minimum stake in TAO for validator eligibility
+validator_hotkey = "5G3qVaXzKMPDm5AJ3dpzbpUC27kpccBvDwzSWXrq8M6qMmbC" # Optional
 ```
+
+### Validator Assignment Strategy
+
+The miner supports assignment of executors to validators based on these strategies:
+
+- **`highest_stake`** (default): Assigns executors to a single validator based on stake
+  - If `validator_hotkey` is specified in config, assigns to that validator (if above threshold and online)
+  - Otherwise, assigns to the highest staked validator above the threshold
+  - Configurable minimum stake threshold (default: 6000 TAO)
+  - Only considers validators that are online (have axon endpoints)
+  - Increases security by working only with the most invested validators
+
+- **`round_robin`**: Distributes executors evenly across all eligible validators
+  - Useful for testing or when stake-based assignment is not desired
+
+Configuration example for specific validator selection:
+
+```toml
+[validator_assignment]
+enabled = true
+strategy = "highest_stake"
+min_stake_threshold = 6000.0
+validator_hotkey = "5G3qVaXzKMPDm5AJ3dpzbpUC27kpccBvDwzSWXrq8M6qMmbC"  # Optional
+```
+
+When validator assignment is disabled (`enabled = false`), all executors are made available to all validators. For production deployments, it's recommended to enable assignment with the `highest_stake` strategy to ensure your resources are allocated to the most reliable validators.
 
 ### 3. Set Up Executors
 


### PR DESCRIPTION
## Summary

* Add HighestStakeAssignment strategy to assign executors to high-stake validators
* Update configuration to support strategy selection and minimum stake threshold
* Set highest_stake as default strategy with 6000 TAO minimum stake
* Store validator stake information in database for assignment decisions
* Filter validators by both stake amount and online status for reliability
* Update all config examples to use new stake-based assignment defaults
* Document validator assignment strategies in architecture and miner docs
* Ensure backward compatibility with round_robin strategy for testing

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

### How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [X] Unit tests pass (`cargo test`)
- [X] Integration tests pass
- [X] Manual testing completed

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have run `cargo fmt` to format my code
- [X] I have run `cargo clippy` and addressed all warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published
