### PR TITLE
fix: enable CI workflow for PRs targeting any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main, develop ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Previously CI only ran on PRs targeting main/develop branches. This change removes the branch restriction for pull_request triggers, allowing CI to run on PRs targeting feature branches like 'feat/rental-system'.

🤖 Generated with [Claude Code](https://claude.ai/code)