### PR TITLE
fix: properly clone the SshSessionOrchestrator

### DIFF
--- a/crates/basilica-miner/src/executors/grpc_client.rs
+++ b/crates/basilica-miner/src/executors/grpc_client.rs
@@ -37,6 +37,7 @@ impl Default for ExecutorGrpcConfig {
 }
 
 /// gRPC client for communicating with executors
+#[derive(Clone)]
 pub struct ExecutorGrpcClient {
     config: ExecutorGrpcConfig,
     auth_service: Option<Arc<ExecutorAuthService>>,

--- a/crates/basilica-miner/src/ssh/session_orchestrator.rs
+++ b/crates/basilica-miner/src/ssh/session_orchestrator.rs
@@ -629,7 +629,7 @@ impl Clone for SshSessionOrchestrator {
             sessions: self.sessions.clone(),
             sessions_by_validator: self.sessions_by_validator.clone(),
             executor_manager: self.executor_manager.clone(),
-            executor_grpc_client: ExecutorGrpcClient::new(ExecutorGrpcConfig::default()),
+            executor_grpc_client: self.executor_grpc_client.clone(),
             rate_limits: self.rate_limits.clone(),
             config: self.config.clone(),
         }


### PR DESCRIPTION
## Summary

The orchestrator wasn't clone properly which caused the requests that where made using cloned type to not contain auth. Fix by properly cloning the type.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cloning behavior for session orchestrators to retain existing client configurations.
  * Enhanced client objects to support duplication without manual implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->