### PR TITLE
feat(validator): add rental metrics tracking for Prometheus monitoring

### DIFF
--- a/crates/basilica-validator/src/cli/handlers/service.rs
+++ b/crates/basilica-validator/src/cli/handlers/service.rs
@@ -388,15 +388,22 @@ async fn start_validator_services(
     );
 
     let rental_manager = if let Some(ref bittensor_service) = bittensor_service {
-        Some(
-            create_rental_manager(
-                &config,
-                validator_hotkey.clone(),
-                persistence_arc.clone(),
-                bittensor_service.clone(),
+        // Only create rental manager if metrics are enabled
+        if let Some(ref metrics) = validator_metrics {
+            Some(
+                create_rental_manager(
+                    &config,
+                    validator_hotkey.clone(),
+                    persistence_arc.clone(),
+                    bittensor_service.clone(),
+                    metrics.prometheus(), // Pass prometheus metrics
+                )
+                .await?,
             )
-            .await?,
-        )
+        } else {
+            tracing::warn!("Rental manager disabled: metrics must be enabled for rentals");
+            None
+        }
     } else {
         None
     };

--- a/crates/basilica-validator/src/metrics/prometheus_metrics.rs
+++ b/crates/basilica-validator/src/metrics/prometheus_metrics.rs
@@ -157,6 +157,12 @@ impl ValidatorPrometheusMetrics {
             "GPU profiles for miners"
         );
 
+        // Rental metrics
+        describe_gauge!(
+            "basilica_validator_executor_rental_status",
+            "Executor rental status (1=rented, 0=available)"
+        );
+
         Ok(Self {
             last_collection: Arc::new(RwLock::new(SystemTime::now())),
             persistence,
@@ -311,6 +317,22 @@ impl ValidatorPrometheusMetrics {
             "executor_id" => executor_id.to_string()
         )
         .set(count as f64);
+    }
+
+    /// Record executor rental status
+    pub fn record_executor_rental_status(
+        &self,
+        executor_id: &str,
+        miner_uid: u16,
+        gpu_type: &str,
+        is_rented: bool,
+    ) {
+        gauge!("basilica_validator_executor_rental_status",
+            "executor_id" => executor_id.to_string(),
+            "miner_uid" => miner_uid.to_string(),
+            "gpu_type" => gpu_type.to_string()
+        )
+        .set(if is_rented { 1.0 } else { 0.0 });
     }
 
     /// Collect system metrics periodically

--- a/crates/basilica-validator/src/metrics/prometheus_metrics.rs
+++ b/crates/basilica-validator/src/metrics/prometheus_metrics.rs
@@ -162,6 +162,10 @@ impl ValidatorPrometheusMetrics {
             "basilica_validator_executor_rental_status",
             "Executor rental status (1=rented, 0=available)"
         );
+        describe_counter!(
+            "basilica_validator_rentals_created_total",
+            "Total number of rentals created"
+        );
 
         Ok(Self {
             last_collection: Arc::new(RwLock::new(SystemTime::now())),
@@ -333,6 +337,15 @@ impl ValidatorPrometheusMetrics {
             "gpu_type" => gpu_type.to_string()
         )
         .set(if is_rented { 1.0 } else { 0.0 });
+    }
+
+    /// Record rental creation
+    pub fn record_rental_created(&self, miner_uid: u16, gpu_type: &str) {
+        counter!("basilica_validator_rentals_created_total",
+            "miner_uid" => miner_uid.to_string(),
+            "gpu_type" => gpu_type.to_string()
+        )
+        .increment(1);
     }
 
     /// Collect system metrics periodically

--- a/crates/basilica-validator/src/persistence/simple_persistence.rs
+++ b/crates/basilica-validator/src/persistence/simple_persistence.rs
@@ -1792,7 +1792,7 @@ impl ValidatorPersistence for SimplePersistence {
         self.query_rentals(filter).await
     }
 
-    async fn query_non_terminal_rentals(&self) -> anyhow::Result<Vec<RentalInfo>> {
+    async fn query_non_terminated_rentals(&self) -> anyhow::Result<Vec<RentalInfo>> {
         let filter = RentalFilter {
             exclude_states: Some(vec![RentalState::Stopped, RentalState::Failed]),
             order_by_created_desc: true,

--- a/crates/basilica-validator/src/persistence/validator_persistence.rs
+++ b/crates/basilica-validator/src/persistence/validator_persistence.rs
@@ -20,7 +20,7 @@ pub trait ValidatorPersistence: Send + Sync {
     async fn list_validator_rentals(&self, validator_hotkey: &str) -> Result<Vec<RentalInfo>>;
 
     /// Query all rentals that are not in terminal states (not Stopped or Failed)
-    async fn query_non_terminal_rentals(&self) -> Result<Vec<RentalInfo>>;
+    async fn query_non_terminated_rentals(&self) -> Result<Vec<RentalInfo>>;
 
     /// Delete rental
     async fn delete_rental(&self, rental_id: &str) -> Result<()>;

--- a/crates/basilica-validator/src/rental/mod.rs
+++ b/crates/basilica-validator/src/rental/mod.rs
@@ -279,15 +279,21 @@ impl RentalManager {
         // Save to persistence
         self.persistence.save_rental(&rental_info).await?;
 
-        // Record rental metric
+        // Record rental metrics
         if let Some(miner_uid) = extract_miner_uid(&request.executor_id) {
             let gpu_type = get_gpu_type(&rental_info.executor_details);
+
+            // Record rental status
             self.metrics.record_executor_rental_status(
                 &request.executor_id,
                 miner_uid,
                 &gpu_type,
                 true, // is_rented = true
             );
+
+            // Record rental creation
+            self.metrics.record_rental_created(miner_uid, &gpu_type);
+
             tracing::debug!(
                 "Recorded rental start for executor {} (miner_uid: {}, gpu_type: {})",
                 request.executor_id,

--- a/crates/basilica-validator/src/rental/mod.rs
+++ b/crates/basilica-validator/src/rental/mod.rs
@@ -17,6 +17,7 @@ pub use deployment::DeploymentManager;
 pub use monitoring::{DatabaseHealthMonitor, LogStreamer};
 pub use types::*;
 
+use crate::metrics::ValidatorPrometheusMetrics;
 use crate::miner_prover::miner_client::{AuthenticatedMinerConnection, MinerClient};
 use crate::persistence::{SimplePersistence, ValidatorPersistence};
 use crate::ssh::ValidatorSshKeyManager;
@@ -36,6 +37,8 @@ pub struct RentalManager {
     miner_client: Arc<MinerClient>,
     /// SSH key manager for validator keys
     ssh_key_manager: Option<Arc<ValidatorSshKeyManager>>,
+    /// Metrics for tracking rental status (required)
+    metrics: Arc<ValidatorPrometheusMetrics>,
 }
 
 /// Parse SSH host from credentials string format "user@host:port"
@@ -52,6 +55,30 @@ fn parse_ssh_host(credentials: &str) -> Result<&str> {
 
     Ok(host)
 }
+
+/// Extract miner UID from executor_id format: "miner{uid}__{uuid}"
+pub(crate) fn extract_miner_uid(executor_id: &str) -> Option<u16> {
+    if let Some(miner_part) = executor_id.split("__").next() {
+        if let Some(uid_str) = miner_part.strip_prefix("miner") {
+            return uid_str.parse().ok();
+        }
+    }
+    None
+}
+
+/// Get normalized GPU type from executor details
+pub(crate) fn get_gpu_type(
+    executor_details: &Option<crate::api::types::ExecutorDetails>,
+) -> String {
+    use crate::gpu::categorization::GpuCategorizer;
+
+    executor_details
+        .as_ref()
+        .and_then(|details| details.gpu_specs.first())
+        .map(|gpu| GpuCategorizer::normalize_gpu_model(&gpu.name))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
 impl RentalManager {
     /// Helper function to create a ContainerClient with SSH credentials
     fn create_container_client(&self, ssh_credentials: &str) -> Result<ContainerClient> {
@@ -69,14 +96,16 @@ impl RentalManager {
         miner_client: Arc<MinerClient>,
         persistence: Arc<SimplePersistence>,
         ssh_key_manager: Arc<ValidatorSshKeyManager>,
+        metrics: Arc<ValidatorPrometheusMetrics>,
     ) -> Self {
         let deployment_manager = Arc::new(DeploymentManager::new());
         let log_streamer = Arc::new(LogStreamer::new());
 
-        // Create health monitor with SSH key manager
+        // Create health monitor with SSH key manager and metrics
         let health_monitor = Arc::new(DatabaseHealthMonitor::new(
             persistence.clone(),
             ssh_key_manager.clone(),
+            metrics.clone(),
         ));
 
         Self {
@@ -86,12 +115,50 @@ impl RentalManager {
             health_monitor,
             miner_client,
             ssh_key_manager: Some(ssh_key_manager),
+            metrics,
         }
     }
 
     // Start the monitoring loop
     pub fn start_monitor(&self) {
         self.health_monitor.start_monitoring_loop();
+    }
+
+    /// Initialize metrics for all existing rentals on startup
+    pub async fn initialize_rental_metrics(&self) -> Result<()> {
+        // Query all non-terminal rentals from persistence
+        let rentals = self.persistence.query_non_terminated_rentals().await?;
+
+        let rental_count = rentals.len();
+
+        for rental in rentals {
+            if let Some(miner_uid) = extract_miner_uid(&rental.executor_id) {
+                let gpu_type = get_gpu_type(&rental.executor_details);
+
+                // Set metric based on rental state
+                let is_rented = matches!(
+                    rental.state,
+                    RentalState::Active | RentalState::Provisioning | RentalState::Stopping
+                );
+
+                self.metrics.record_executor_rental_status(
+                    &rental.executor_id,
+                    miner_uid,
+                    &gpu_type,
+                    is_rented,
+                );
+
+                tracing::info!(
+                    "Initialized rental metric for executor {} (state: {:?}, is_rented: {})",
+                    rental.executor_id,
+                    rental.state,
+                    is_rented
+                );
+            }
+        }
+
+        tracing::info!("Initialized metrics for {} existing rentals", rental_count);
+        Ok(())
     }
 
     /// Start a new rental
@@ -212,6 +279,23 @@ impl RentalManager {
         // Save to persistence
         self.persistence.save_rental(&rental_info).await?;
 
+        // Record rental metric
+        if let Some(miner_uid) = extract_miner_uid(&request.executor_id) {
+            let gpu_type = get_gpu_type(&rental_info.executor_details);
+            self.metrics.record_executor_rental_status(
+                &request.executor_id,
+                miner_uid,
+                &gpu_type,
+                true, // is_rented = true
+            );
+            tracing::debug!(
+                "Recorded rental start for executor {} (miner_uid: {}, gpu_type: {})",
+                request.executor_id,
+                miner_uid,
+                gpu_type
+            );
+        }
+
         // Health monitoring happens automatically via the database monitor loop
 
         Ok(RentalResponse {
@@ -280,6 +364,23 @@ impl RentalManager {
         let mut updated_rental = rental_info.clone();
         updated_rental.state = RentalState::Stopped;
         self.persistence.save_rental(&updated_rental).await?;
+
+        // Clear rental metric
+        if let Some(miner_uid) = extract_miner_uid(&rental_info.executor_id) {
+            let gpu_type = get_gpu_type(&rental_info.executor_details);
+            self.metrics.record_executor_rental_status(
+                &rental_info.executor_id,
+                miner_uid,
+                &gpu_type,
+                false, // is_rented = false
+            );
+            tracing::debug!(
+                "Cleared rental metric for executor {} (miner_uid: {}, gpu_type: {})",
+                rental_info.executor_id,
+                miner_uid,
+                gpu_type
+            );
+        }
 
         Ok(())
     }


### PR DESCRIPTION
merge after #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus-based observability for rentals, including a rental status gauge and a “rentals created” counter with descriptive labels.
  * Metrics are backfilled on startup to reflect existing rentals and update live on start/stop and terminal state transitions.
  * Rental monitoring and metric updates are activated when metrics are enabled in the validator configuration, improving visibility into rental lifecycle and utilization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->