### PR TITLE
fix(cli): update GPU rental defaults for proper GPU allocation

### DIFF
--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -242,7 +242,7 @@ pub async fn handle_up(
             cpu_cores: options.cpu_cores.unwrap_or(1.0),
             memory_mb: options.memory_mb.unwrap_or(1024),
             storage_mb: 102400,
-            gpu_count: options.gpu_min.unwrap_or(0),
+            gpu_count: options.gpu_min.unwrap_or(1),
             gpu_types: options.gpu_type.map(|t| vec![t]).unwrap_or_default(),
         },
         command,

--- a/crates/basilica-cli/src/config/mod.rs
+++ b/crates/basilica-cli/src/config/mod.rs
@@ -101,7 +101,7 @@ pub struct ImageConfig {
 impl Default for ImageConfig {
     fn default() -> Self {
         Self {
-            name: "nvidia/cuda:12.2.0-runtime-ubuntu22.04".to_string(),
+            name: "nvidia/cuda:12.8.0-runtime-ubuntu22.04".to_string(),
         }
     }
 }


### PR DESCRIPTION
- Set minimum GPU count to 1 instead of 0 in rental requests
- Update default CUDA image to 12.8.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Default GPU request now provisions 1 GPU when no minimum is specified, enabling GPU-backed rentals by default. You can still set GPU values explicitly.
  * Updated the default CUDA runtime image to 12.8.0 (Ubuntu 22.04) for improved compatibility and performance. Existing setups with explicit images are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->