### PR TITLE
ci(release): compile binaries using GitHub native runners and update install script

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -55,7 +55,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Basilica CLI ${{ steps.version.outputs.version }}
           draft: false
-          prerelease: false
+          prerelease: true
           generate_release_notes: true
           body: |
             ### Installation

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Basilica CLI ${{ steps.version.outputs.version }}
@@ -149,7 +149,7 @@ jobs:
 
       # Upload binary
       - name: Upload Release Binary
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.create-release.outputs.tag }}
           files: |

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -60,12 +60,19 @@ jobs:
             Download the appropriate binary for your platform from the assets below.
             
             #### Verify checksums
+            Download both the binary and its corresponding `.sha256` file, then:
             ```bash
-            # macOS/Linux
-            shasum -a 256 -c basilica-cli-checksums.txt
+            # For macOS ARM64
+            shasum -a 256 -c basilica-darwin-arm64.sha256
             
-            # Or individual file
-            shasum -a 256 basilica-darwin-arm64
+            # For macOS Intel
+            shasum -a 256 -c basilica-darwin-amd64.sha256
+            
+            # For Linux x86_64
+            shasum -a 256 -c basilica-linux-amd64.sha256
+            
+            # For Linux ARM64
+            shasum -a 256 -c basilica-linux-arm64.sha256
             ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -161,38 +168,6 @@ jobs:
           files: |
             basilica-${{ matrix.suffix }}
             basilica-${{ matrix.suffix }}.sha256
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Generate consolidated checksums file
-  generate-checksums:
-    needs: [create-release, build-binaries]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Generate consolidated checksums
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Download all released binaries
-          gh release download ${{ needs.create-release.outputs.tag }} \
-            --pattern "basilica-*" \
-            --skip-existing \
-            --repo ${{ github.repository }}
-          
-          # Filter out individual .sha256 files and generate consolidated checksums
-          ls basilica-* | grep -v ".sha256$" | xargs sha256sum > basilica-cli-checksums.txt
-          
-          # Display checksums for verification
-          echo "Generated checksums:"
-          cat basilica-cli-checksums.txt
-          
-      - name: Upload checksums file
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ needs.create-release.outputs.tag }}
-          files: basilica-cli-checksums.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -3,11 +3,11 @@ name: Release CLI
 on:
   push:
     tags:
-      - 'basilica-v*'
+      - "basilica-cli-v*"
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g., basilica-v0.1.0)'
+        description: "Tag to release (e.g., basilica-cli-v0.1.0)"
         required: true
         type: string
 
@@ -28,20 +28,26 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Extract version
         id: version
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             VERSION="${{ github.event.inputs.tag }}"
+            # Validate that the tag starts with basilica-cli-v
+            if [[ ! "$VERSION" =~ ^basilica-cli-v ]]; then
+              echo "Error: Tag must start with 'basilica-cli-v' prefix"
+              echo "Example: basilica-cli-v0.1.0"
+              exit 1
+            fi
           else
             VERSION="${GITHUB_REF#refs/tags/}"
           fi
-          # Remove 'basilica-v' prefix to get clean version
-          CLEAN_VERSION="${VERSION#basilica-v}"
+          # Remove 'basilica-cli-v' prefix to get clean version
+          CLEAN_VERSION="${VERSION#basilica-cli-v}"
           echo "version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
           echo "tag=$VERSION" >> $GITHUB_OUTPUT
-        
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1
@@ -52,28 +58,9 @@ jobs:
           prerelease: false
           generate_release_notes: true
           body: |
-            ## Basilica CLI ${{ steps.version.outputs.version }}
-            
             ### Installation
             
-            #### Direct Download
-            Download the appropriate binary for your platform from the assets below.
-            
-            #### Verify checksums
-            Download both the binary and its corresponding `.sha256` file, then:
-            ```bash
-            # For macOS ARM64
-            shasum -a 256 -c basilica-darwin-arm64.sha256
-            
-            # For macOS Intel
-            shasum -a 256 -c basilica-darwin-amd64.sha256
-            
-            # For Linux x86_64
-            shasum -a 256 -c basilica-linux-amd64.sha256
-            
-            # For Linux ARM64
-            shasum -a 256 -c basilica-linux-arm64.sha256
-            ```
+            For installation instructions, please visit [https://basilica.ai/](https://basilica.ai/)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -88,15 +75,15 @@ jobs:
             suffix: linux-amd64
           # Linux ARM64 - native build on GitHub ARM runner
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04-arm  # Free GitHub ARM runner
+            os: ubuntu-22.04-arm # Free GitHub ARM runner
             suffix: linux-arm64
           # macOS Intel build
           - target: x86_64-apple-darwin
-            os: macos-13  # Use macos-13 for Intel (x86_64) runners
+            os: macos-13 # Use macos-13 for Intel (x86_64) runners
             suffix: darwin-amd64
           # macOS Apple Silicon build
           - target: aarch64-apple-darwin
-            os: macos-14  # Use macos-14 for Apple Silicon (M1) runners
+            os: macos-14 # Use macos-14 for Apple Silicon (M1) runners
             suffix: darwin-arm64
     runs-on: ${{ matrix.os }}
     env:
@@ -106,12 +93,12 @@ jobs:
       RUST_BACKTRACE: short
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      
+
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -133,7 +120,7 @@ jobs:
       # Build binary
       - name: Build binary
         env:
-          MACOSX_DEPLOYMENT_TARGET: '10.15'  # Ensure compatibility with older macOS versions
+          MACOSX_DEPLOYMENT_TARGET: "10.15" # Ensure compatibility with older macOS versions
           BASILICA_AUTH0_CLIENT_ID: ${{ secrets.BASILICA_AUTH0_CLIENT_ID }}
           BASILICA_AUTH0_AUDIENCE: ${{ secrets.BASILICA_AUTH0_AUDIENCE }}
           BASILICA_AUTH0_ISSUER: ${{ secrets.BASILICA_AUTH0_ISSUER }}
@@ -146,17 +133,17 @@ jobs:
       - name: Prepare binary
         run: |
           chmod +x ./basilica-${{ matrix.suffix }}
-          
+
           # Strip debug symbols to reduce size
           strip ./basilica-${{ matrix.suffix }}
-          
+
           # Generate checksum
           if command -v shasum &> /dev/null; then
             shasum -a 256 ./basilica-${{ matrix.suffix }} > ./basilica-${{ matrix.suffix }}.sha256
           else
             sha256sum ./basilica-${{ matrix.suffix }} > ./basilica-${{ matrix.suffix }}.sha256
           fi
-          
+
           # Display file info
           ls -lh ./basilica-${{ matrix.suffix }}
 
@@ -170,4 +157,3 @@ jobs:
             basilica-${{ matrix.suffix }}.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -56,10 +56,8 @@ jobs:
           name: Basilica CLI ${{ steps.version.outputs.version }}
           draft: false
           prerelease: true
-          generate_release_notes: true
+          generate_release_notes: false
           body: |
-            ### Installation
-            
             For installation instructions, please visit [https://basilica.ai/](https://basilica.ai/)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -119,10 +119,10 @@ jobs:
       - name: Build binary
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.15" # Ensure compatibility with older macOS versions
-          BASILICA_AUTH0_CLIENT_ID: ${{ secrets.BASILICA_AUTH0_CLIENT_ID }}
-          BASILICA_AUTH0_AUDIENCE: ${{ secrets.BASILICA_AUTH0_AUDIENCE }}
-          BASILICA_AUTH0_ISSUER: ${{ secrets.BASILICA_AUTH0_ISSUER }}
-          BASILICA_AUTH0_DOMAIN: ${{ secrets.BASILICA_AUTH0_DOMAIN }}
+          BASILICA_AUTH0_CLIENT_ID: ${{ vars.BASILICA_AUTH0_CLIENT_ID }}
+          BASILICA_AUTH0_AUDIENCE: ${{ vars.BASILICA_AUTH0_AUDIENCE }}
+          BASILICA_AUTH0_ISSUER: ${{ vars.BASILICA_AUTH0_ISSUER }}
+          BASILICA_AUTH0_DOMAIN: ${{ vars.BASILICA_AUTH0_DOMAIN }}
         run: |
           cargo build --release --locked --target ${{ matrix.target }} -p basilica-cli
           cp target/${{ matrix.target }}/release/basilica ./basilica-${{ matrix.suffix }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -56,12 +56,6 @@ jobs:
             
             ### Installation
             
-            #### macOS (Homebrew)
-            ```bash
-            brew tap tplr-ai/basilica
-            brew install basilica
-            ```
-            
             #### Direct Download
             Download the appropriate binary for your platform from the assets below.
             
@@ -81,84 +75,64 @@ jobs:
     strategy:
       matrix:
         include:
-          # Linux builds (using Docker for consistency)
+          # Linux x86_64 - native build on Ubuntu 22.04 LTS
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             suffix: linux-amd64
-            use_docker: true
+          # Linux ARM64 - native build on GitHub ARM runner
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04-arm  # Free GitHub ARM runner
             suffix: linux-arm64
-            use_docker: true
           # macOS Intel build
           - target: x86_64-apple-darwin
             os: macos-13  # Use macos-13 for Intel (x86_64) runners
             suffix: darwin-amd64
-            use_docker: false
           # macOS Apple Silicon build
           - target: aarch64-apple-darwin
             os: macos-14  # Use macos-14 for Apple Silicon (M1) runners
             suffix: darwin-arm64
-            use_docker: false
     runs-on: ${{ matrix.os }}
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: 0
+      CARGO_NET_RETRY: 10
+      RUST_BACKTRACE: short
     steps:
       - uses: actions/checkout@v4
       
       - name: Install Rust
-        if: matrix.use_docker == false
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
       
       - name: Setup Rust cache
-        if: matrix.use_docker == false
         uses: Swatinem/rust-cache@v2
         with:
           key: release-cli-${{ matrix.target }}
 
+      # Install dependencies for Linux
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler pkg-config libssl-dev build-essential
+
       # Install dependencies for macOS
       - name: Install dependencies (macOS)
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
+        if: runner.os == 'macOS'
         run: |
           brew install protobuf pkg-config openssl
 
-      # Build using Docker for Linux
-      - name: Build with Docker (Linux)
-        if: matrix.use_docker == true
-        run: |
-          if [[ "${{ matrix.target }}" == "x86_64-unknown-linux-gnu" ]]; then
-            ARCH="amd64"
-          else
-            ARCH="arm64"
-          fi
-          
-          ./scripts/cli/build.sh \
-            --architectures $ARCH \
-            --single-arch \
-            --no-extract
-          
-          # Extract binary from Docker image
-          docker create --name extract basilica/cli:latest
-          docker cp extract:/usr/local/bin/basilica ./basilica-${{ matrix.suffix }}
-          docker rm extract
-
-      # Build natively for macOS
-      - name: Build natively (macOS)
-        if: matrix.use_docker == false
+      # Build binary
+      - name: Build binary
         env:
           MACOSX_DEPLOYMENT_TARGET: '10.15'  # Ensure compatibility with older macOS versions
+          BASILICA_AUTH0_CLIENT_ID: ${{ secrets.BASILICA_AUTH0_CLIENT_ID }}
+          BASILICA_AUTH0_AUDIENCE: ${{ secrets.BASILICA_AUTH0_AUDIENCE }}
+          BASILICA_AUTH0_ISSUER: ${{ secrets.BASILICA_AUTH0_ISSUER }}
+          BASILICA_AUTH0_DOMAIN: ${{ secrets.BASILICA_AUTH0_DOMAIN }}
         run: |
-          # For cross-compilation on Apple Silicon to Intel
-          if [[ "${{ matrix.target }}" == "x86_64-apple-darwin" ]] && [[ "$(uname -m)" == "arm64" ]]; then
-            export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=x86_64-apple-darwin14-clang
-          fi
-          
-          # For cross-compilation on Intel to Apple Silicon
-          if [[ "${{ matrix.target }}" == "aarch64-apple-darwin" ]] && [[ "$(uname -m)" == "x86_64" ]]; then
-            export CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=aarch64-apple-darwin14-clang
-          fi
-          
-          cargo build --release --target ${{ matrix.target }} -p basilica-cli
+          cargo build --release --locked --target ${{ matrix.target }} -p basilica-cli
           cp target/${{ matrix.target }}/release/basilica ./basilica-${{ matrix.suffix }}
 
       # Make binary executable and generate checksums
@@ -167,11 +141,7 @@ jobs:
           chmod +x ./basilica-${{ matrix.suffix }}
           
           # Strip debug symbols to reduce size
-          if [[ "${{ matrix.os }}" == "macos-13" ]] || [[ "${{ matrix.os }}" == "macos-14" ]]; then
-            strip ./basilica-${{ matrix.suffix }}
-          elif [[ "${{ matrix.use_docker }}" == "false" ]]; then
-            strip ./basilica-${{ matrix.suffix }}
-          fi
+          strip ./basilica-${{ matrix.suffix }}
           
           # Generate checksum
           if command -v shasum &> /dev/null; then
@@ -226,17 +196,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # # Update Homebrew formula (optional - requires separate tap repository)
-  # update-homebrew:
-  #   needs: [create-release, generate-checksums]
-  #   runs-on: ubuntu-latest
-  #   if: github.repository == 'tplr-ai/basilica' && contains(github.ref, 'refs/tags/')  # Only run on main repo for tag pushes
-  #   steps:
-  #     - name: Update Homebrew Formula
-  #       uses: peter-evans/repository-dispatch@v2
-  #       if: vars.HOMEBREW_TAP_TOKEN != ''  # Only run if token is configured
-  #       with:
-  #         token: ${{ secrets.HOMEBREW_TAP_TOKEN }}  # Requires PAT with repo access to tap
-  #         repository: tplr-ai/homebrew-basilica  # Assumes you have this tap repo
-  #         event-type: update-formula
-  #         client-payload: '{"version": "${{ needs.create-release.outputs.version }}", "tag": "${{ needs.create-release.outputs.tag }}"}'


### PR DESCRIPTION
## Summary
- Switch from cross-compilation to native builds using GitHub's native runners
- Update install script to dynamically fetch latest CLI releases from GitHub API
- Improve release workflow configuration and error handling

## Changes

### Release Workflow (.github/workflows/release-cli.yml)
- **Native Builds**: Replace Docker-based cross-compilation with native builds on platform-specific GitHub runners
- **ARM64 Support**: Utilize GitHub's `ubuntu-22.04-arm` runners for native ARM64 Linux builds
- **Tag Format**: Change from `basilica-v*` to `basilica-cli-v*` for better clarity
- **Release Configuration**: 
  - Default to pre-release mode for safer releases
  - Disable automatic release notes generation
  - Update to `softprops/action-gh-release@v2`
  - Simplify checksum handling with individual files

### Install Script (scripts/web/install.sh)
- **Dynamic Release Fetching**: Fetch latest stable release from GitHub API instead of hardcoded URL
- **Version Comparison**: Show current vs latest version before update prompt
- **Better Error Handling**: 
  - Handle GitHub API rate limiting gracefully
  - Improve error messages for network issues
  - Add validation for release tag format
- **Repository Configuration**: Support `--repo` flag for testing with different repositories