### PR TITLE
refactor(auth): move token refresh to CLI layer and remove no-auth flag

### DIFF
--- a/crates/basilica-cli/src/auth/token_store.rs
+++ b/crates/basilica-cli/src/auth/token_store.rs
@@ -173,11 +173,6 @@ impl TokenStore {
         Ok(metadata.services.keys().cloned().collect())
     }
 
-    /// Check if access token is expired
-    pub fn is_expired(&self, tokens: &TokenSet) -> bool {
-        tokens.is_expired()
-    }
-
     /// Check if token needs refresh (with 5 minute buffer)
     pub fn needs_refresh(&self, tokens: &TokenSet) -> bool {
         tokens.expires_within(Duration::from_secs(REFRESH_BUFFER_MINUTES * 60))

--- a/crates/basilica-cli/src/auth/types.rs
+++ b/crates/basilica-cli/src/auth/types.rs
@@ -85,9 +85,9 @@ impl TokenSet {
         }
     }
 
-    /// Check if the token needs refresh (expires within 5 minutes)
+    /// Check if the token needs refresh (expires within 60 minutes)
     pub fn needs_refresh(&self) -> bool {
-        self.expires_within(std::time::Duration::from_secs(300))
+        self.expires_within(std::time::Duration::from_secs(60 * 60))
     }
 
     /// Check if the token expires within the specified duration

--- a/crates/basilica-cli/src/cli/args.rs
+++ b/crates/basilica-cli/src/cli/args.rs
@@ -51,16 +51,6 @@ pub struct Args {
     #[arg(long, global = true)]
     pub json: bool,
 
-    /// Bypass OAuth authentication (debug builds only, for testing)
-    #[cfg(debug_assertions)]
-    #[arg(long, global = true, hide = true)]
-    pub no_auth: bool,
-
-    /// Placeholder for release builds to maintain struct compatibility
-    #[cfg(not(debug_assertions))]
-    #[arg(skip)]
-    pub no_auth: bool,
-
     /// Subcommand to execute
     #[command(subcommand)]
     pub command: Commands,
@@ -85,41 +75,39 @@ impl Args {
             #[cfg(debug_assertions)]
             Commands::TestAuth { api } => {
                 if api {
-                    handlers::test_auth::handle_test_api_auth(&config, self.no_auth).await
+                    handlers::test_auth::handle_test_api_auth(&config).await
                 } else {
-                    handlers::test_auth::handle_test_auth(&config, self.no_auth).await
+                    handlers::test_auth::handle_test_auth(&config).await
                 }
             }
 
             // GPU rental operations
             Commands::Ls { filters } => {
-                handlers::gpu_rental::handle_ls(filters, self.json, &config, self.no_auth).await
+                handlers::gpu_rental::handle_ls(filters, self.json, &config).await
             }
             Commands::Up { target, options } => {
-                handlers::gpu_rental::handle_up(target, options, &config, self.no_auth).await
+                handlers::gpu_rental::handle_up(target, options, &config).await
             }
             Commands::Ps { filters } => {
-                handlers::gpu_rental::handle_ps(filters, self.json, &config, self.no_auth).await
+                handlers::gpu_rental::handle_ps(filters, self.json, &config).await
             }
             Commands::Status { target } => {
-                handlers::gpu_rental::handle_status(target, self.json, &config, self.no_auth).await
+                handlers::gpu_rental::handle_status(target, self.json, &config).await
             }
             Commands::Logs { target, options } => {
-                handlers::gpu_rental::handle_logs(target, options, &config, self.no_auth).await
+                handlers::gpu_rental::handle_logs(target, options, &config).await
             }
-            Commands::Down { target } => {
-                handlers::gpu_rental::handle_down(target, &config, self.no_auth).await
-            }
+            Commands::Down { target } => handlers::gpu_rental::handle_down(target, &config).await,
             Commands::Exec { command, target } => {
-                handlers::gpu_rental::handle_exec(target, command, &config, self.no_auth).await
+                handlers::gpu_rental::handle_exec(target, command, &config).await
             }
             Commands::Ssh { target, options } => {
-                handlers::gpu_rental::handle_ssh(target, options, &config, self.no_auth).await
+                handlers::gpu_rental::handle_ssh(target, options, &config).await
             }
             Commands::Cp {
                 source,
                 destination,
-            } => handlers::gpu_rental::handle_cp(source, destination, &config, self.no_auth).await,
+            } => handlers::gpu_rental::handle_cp(source, destination, &config).await,
 
             // Network component delegation
             Commands::Validator { args } => handlers::external::handle_validator(args),

--- a/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
+++ b/crates/basilica-cli/src/cli/handlers/gpu_rental.rs
@@ -28,13 +28,8 @@ use tabled::{settings::Style, Table, Tabled};
 use tracing::debug;
 
 /// Handle the `ls` command - list available executors for rental
-pub async fn handle_ls(
-    filters: ListFilters,
-    json: bool,
-    config: &CliConfig,
-    no_auth: bool,
-) -> Result<()> {
-    let api_client = create_authenticated_client(config, no_auth).await?;
+pub async fn handle_ls(filters: ListFilters, json: bool, config: &CliConfig) -> Result<()> {
+    let api_client = create_authenticated_client(config).await?;
 
     // Build query from filters
     let query = ListAvailableExecutorsQuery {
@@ -150,9 +145,8 @@ pub async fn handle_up(
     target: Option<String>,
     options: UpOptions,
     config: &CliConfig,
-    no_auth: bool,
 ) -> Result<()> {
-    let api_client = create_authenticated_client(config, no_auth).await?;
+    let api_client = create_authenticated_client(config).await?;
 
     // If no target provided, fetch available executors and prompt for selection
     let (target, executor_details) = if let Some(t) = target {
@@ -361,13 +355,8 @@ pub async fn handle_up(
 }
 
 /// Handle the `ps` command - list active rentals
-pub async fn handle_ps(
-    filters: PsFilters,
-    json: bool,
-    config: &CliConfig,
-    no_auth: bool,
-) -> Result<()> {
-    let api_client = create_authenticated_client(config, no_auth).await?;
+pub async fn handle_ps(filters: PsFilters, json: bool, config: &CliConfig) -> Result<()> {
+    let api_client = create_authenticated_client(config).await?;
 
     let spinner = create_spinner("Loading active rentals...");
 
@@ -398,13 +387,8 @@ pub async fn handle_ps(
 }
 
 /// Handle the `status` command - check rental status
-pub async fn handle_status(
-    target: Option<String>,
-    json: bool,
-    config: &CliConfig,
-    no_auth: bool,
-) -> Result<()> {
-    let api_client = create_authenticated_client(config, no_auth).await?;
+pub async fn handle_status(target: Option<String>, json: bool, config: &CliConfig) -> Result<()> {
+    let api_client = create_authenticated_client(config).await?;
 
     // Resolve target rental (fetch and prompt if not provided)
     let target = resolve_target_rental(target, &api_client, false).await?;
@@ -443,10 +427,9 @@ pub async fn handle_logs(
     target: Option<String>,
     options: LogsOptions,
     config: &CliConfig,
-    no_auth: bool,
 ) -> Result<()> {
     // Create API client
-    let api_client = create_authenticated_client(config, no_auth).await?;
+    let api_client = create_authenticated_client(config).await?;
 
     // Resolve target rental (fetch and prompt if not provided)
     let target = resolve_target_rental(target, &api_client, false).await?;
@@ -543,8 +526,8 @@ pub async fn handle_logs(
 }
 
 /// Handle the `down` command - terminate rental
-pub async fn handle_down(target: Option<String>, config: &CliConfig, no_auth: bool) -> Result<()> {
-    let api_client = create_authenticated_client(config, no_auth).await?;
+pub async fn handle_down(target: Option<String>, config: &CliConfig) -> Result<()> {
+    let api_client = create_authenticated_client(config).await?;
 
     // Resolve target rental (fetch and prompt if not provided)
     let rental_id = resolve_target_rental(target, &api_client, false).await?;
@@ -582,10 +565,9 @@ pub async fn handle_exec(
     target: Option<String>,
     command: String,
     config: &CliConfig,
-    no_auth: bool,
 ) -> Result<()> {
     // Create API client to verify rental status
-    let api_client = create_authenticated_client(config, no_auth).await?;
+    let api_client = create_authenticated_client(config).await?;
 
     // Load rental cache first to see what's available for SSH
     let mut cache = RentalCache::load().await?;
@@ -619,10 +601,9 @@ pub async fn handle_ssh(
     target: Option<String>,
     options: crate::cli::commands::SshOptions,
     config: &CliConfig,
-    no_auth: bool,
 ) -> Result<()> {
     // Create API client to verify rental status
-    let api_client = create_authenticated_client(config, no_auth).await?;
+    let api_client = create_authenticated_client(config).await?;
 
     // Load rental cache first to see what's available for SSH
     let mut cache = RentalCache::load().await?;
@@ -656,16 +637,11 @@ pub async fn handle_ssh(
 }
 
 /// Handle the `cp` command - copy files via SSH
-pub async fn handle_cp(
-    source: String,
-    destination: String,
-    config: &CliConfig,
-    no_auth: bool,
-) -> Result<()> {
+pub async fn handle_cp(source: String, destination: String, config: &CliConfig) -> Result<()> {
     debug!("Copying files from {} to {}", source, destination);
 
     // Create API client
-    let api_client = create_authenticated_client(config, no_auth).await?;
+    let api_client = create_authenticated_client(config).await?;
 
     // Load rental cache
     let mut cache = RentalCache::load().await?;

--- a/crates/basilica-cli/src/cli/handlers/test_auth.rs
+++ b/crates/basilica-cli/src/cli/handlers/test_auth.rs
@@ -276,7 +276,7 @@ pub async fn handle_test_auth(config: &CliConfig) -> Result<()> {
     let http_client = reqwest::Client::new();
 
     // Get the bearer token from our client
-    let token = client.get_bearer_token().await.ok_or_else(|| {
+    let token = client.get_bearer_token().ok_or_else(|| {
         CliError::internal("No authentication token found. Please run 'basilica login' first")
     })?;
 
@@ -317,7 +317,7 @@ pub async fn handle_test_auth(config: &CliConfig) -> Result<()> {
         // Display OAuth scopes from the JWT token
         println!("\nToken Scopes:");
         println!("─────────────");
-        match decode_jwt_scopes(&token) {
+        match decode_jwt_scopes(token) {
             Some(scopes) => {
                 if scopes.is_empty() {
                     println!("  No scopes found in token");

--- a/crates/basilica-cli/src/config/mod.rs
+++ b/crates/basilica-cli/src/config/mod.rs
@@ -142,6 +142,7 @@ pub fn create_auth_config_with_port(port: u16) -> crate::auth::types::AuthConfig
             "openid".to_string(),
             "profile".to_string(),
             "email".to_string(),
+            "offline_access".to_string(), // Required for refresh tokens
             "rentals:*".to_string(),      // All rental operations
             "executors:list".to_string(), // List available executors
         ],


### PR DESCRIPTION
## Summary
- Moved token refresh logic from API client (reactive) to CLI layer (proactive)
- Removed debug-only `no-auth` bypass flag for cleaner authentication flow
- Simplified API client by removing complex retry mechanisms

## Motivation
This refactoring improves separation of concerns by moving authentication logic to the CLI layer where it belongs, making the API client simpler and more focused on HTTP communication.

## Changes

### API Client (`basilica-api`)
- Removed `TokenRefresh` trait and automatic 401 retry logic
- Removed `token_refresher` field and `with_token_refresher` builder method
- Simplified all HTTP methods by removing retry logic on 401 responses
- Added `set_bearer_token` and `clear_bearer_token` methods for direct token management

### CLI Client (`basilica-cli`)
- Implemented pre-emptive token refresh in `get_valid_jwt_token`
- Tokens are now refreshed before creating the API client if they expire within 60 minutes
- Removed all `no_auth` parameter passing throughout the codebase
- Removed `CliTokenRefresher` struct as it's no longer needed

### Authentication Testing
- Enhanced `test-auth` command to verify token refresh capability
- Added offline_access scope verification
- Added comprehensive token status reporting

## Testing
- Token refresh is now tested explicitly in the `test-auth` command
- All authentication flows have been verified to work with the new proactive refresh approach
- Removed obsolete token refresh tests from API client

## Type of Change
- [x] Refactoring (code restructuring without functional changes)
- [x] Code cleanup (removing dead code and debug flags)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CLI shows token status and expiry during auth tests; OAuth now requests offline_access to enable refresh tokens.

- Changes
  - Automatic token refresh on 401 removed; callers manage tokens explicitly.
  - CLI no-auth flag removed — authentication is required.
  - Token “needs refresh” window increased from 5 to 60 minutes.
  - Client exposes a simple, readable bearer token API.

- Refactor
  - Simplified client request flow and improved error classification (auth, authorization, rate limits, etc.).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->