### PR TITLE
refactor(rental): make executor_details required with proper defaults

### DIFF
--- a/crates/basilica-validator/src/api/rental_routes.rs
+++ b/crates/basilica-validator/src/api/rental_routes.rs
@@ -368,32 +368,10 @@ pub async fn get_rental_status(
         })?;
 
     // Convert RentalStatus to RentalStatusResponse
-    use crate::api::types::{
-        CpuSpec, ExecutorDetails, RentalStatus as ApiRentalStatus, RentalStatusResponse,
-    };
+    use crate::api::types::{RentalStatus as ApiRentalStatus, RentalStatusResponse};
 
-    // Use executor details from rental info if available, otherwise fetch from database
-    let executor = if let Some(executor_details) = rental_info.executor_details {
-        executor_details
-    } else {
-        // Try to fetch executor details from database
-        state
-            .persistence
-            .get_executor_details(&rental_info.executor_id, &rental_info.miner_id)
-            .await
-            .ok()
-            .flatten()
-            .unwrap_or_else(|| ExecutorDetails {
-                id: rental_info.executor_id.clone(),
-                gpu_specs: vec![],
-                cpu_specs: CpuSpec {
-                    cores: 0,
-                    model: "unknown".to_string(),
-                    memory_gb: 0,
-                },
-                location: None,
-            })
-    };
+    // Use executor details from rental info directly
+    let executor = rental_info.executor_details.clone();
 
     let response = RentalStatusResponse {
         rental_id: status.rental_id,

--- a/crates/basilica-validator/src/persistence/simple_persistence.rs
+++ b/crates/basilica-validator/src/persistence/simple_persistence.rs
@@ -893,11 +893,16 @@ impl SimplePersistence {
     }
 
     /// Helper function to parse a rental row from the database
-    fn parse_rental_row(&self, row: sqlx::sqlite::SqliteRow) -> Result<RentalInfo, anyhow::Error> {
+    fn parse_rental_row(
+        &self,
+        row: sqlx::sqlite::SqliteRow,
+        executor_details: crate::api::types::ExecutorDetails,
+    ) -> Result<RentalInfo, anyhow::Error> {
         let state_str: String = row.get("state");
         let created_at_str: String = row.get("created_at");
         let container_spec_str: String = row.get("container_spec");
         let rental_id: String = row.get("id");
+        let executor_id: String = row.get("executor_id");
 
         // Use existing parse_rental_state for consistency
         let state = Self::parse_rental_state(&state_str, &rental_id);
@@ -905,7 +910,7 @@ impl SimplePersistence {
         Ok(RentalInfo {
             rental_id,
             validator_hotkey: row.get("validator_hotkey"),
-            executor_id: row.get("executor_id"),
+            executor_id,
             container_id: row.get("container_id"),
             ssh_session_id: row.get("ssh_session_id"),
             ssh_credentials: row.get("ssh_credentials"),
@@ -913,7 +918,7 @@ impl SimplePersistence {
             created_at: DateTime::parse_from_rfc3339(&created_at_str)?.with_timezone(&Utc),
             container_spec: serde_json::from_str(&container_spec_str)?,
             miner_id: row.get::<String, _>("miner_id"),
-            executor_details: None, // Will be populated lazily when needed
+            executor_details,
         })
     }
 
@@ -964,10 +969,35 @@ impl SimplePersistence {
         let query = builder.build();
         let rows = query.fetch_all(&self.pool).await?;
 
-        // Parse all rows using helper
-        rows.into_iter()
-            .map(|row| self.parse_rental_row(row))
-            .collect()
+        // Parse all rows and fetch executor details for each
+        let mut rentals = Vec::new();
+        for row in rows {
+            // Extract executor_id and miner_id from the row first
+            let executor_id: String = row.get("executor_id");
+            let miner_id: String = row.get("miner_id");
+
+            // Fetch executor details or use defaults if not found
+            let executor_details = match self.get_executor_details(&executor_id, &miner_id).await {
+                Ok(Some(details)) => details,
+                _ => {
+                    // Default executor details if not found
+                    crate::api::types::ExecutorDetails {
+                        id: executor_id.clone(),
+                        gpu_specs: vec![],
+                        cpu_specs: crate::api::types::CpuSpec {
+                            cores: 0,
+                            model: "Unknown".to_string(),
+                            memory_gb: 0,
+                        },
+                        location: None,
+                    }
+                }
+            };
+
+            rentals.push(self.parse_rental_row(row, executor_details)?);
+        }
+
+        Ok(rentals)
     }
 
     /// Helper function to convert database row to Rental

--- a/crates/basilica-validator/src/rental/types.rs
+++ b/crates/basilica-validator/src/rental/types.rs
@@ -117,7 +117,7 @@ pub struct RentalInfo {
     pub created_at: DateTime<Utc>,
     pub container_spec: ContainerSpec,
     pub miner_id: String,
-    pub executor_details: Option<crate::api::types::ExecutorDetails>,
+    pub executor_details: crate::api::types::ExecutorDetails,
 }
 
 /// Rental status


### PR DESCRIPTION
## Summary

Make executor_details a required field in RentalInfo to simplify code and ensure consistent data availability.

## Motivation
This refactor improves code reliability by ensuring executor details are always available, eliminating the need for optional checks throughout the codebase. When executor details are missing from the database, we now provide sensible defaults instead of None.

## Type of Change
- [x] Refactoring (code restructuring without feature changes)
- [x] Code quality improvement