### PR TITLE
fix(persistence): add miner_id to table joins to prevent duplications

### DIFF
--- a/crates/basilica-validator/src/persistence/simple_persistence.rs
+++ b/crates/basilica-validator/src/persistence/simple_persistence.rs
@@ -699,10 +699,10 @@ impl SimplePersistence {
             JOIN miners m ON me.miner_id = m.id
             LEFT JOIN rentals r ON me.executor_id = r.executor_id
                 AND r.state IN ('Active', 'Provisioning', 'active', 'provisioning')
-            LEFT JOIN gpu_uuid_assignments gua ON me.executor_id = gua.executor_id
-            LEFT JOIN executor_hardware_profile ehp ON me.executor_id = ehp.executor_id
-            LEFT JOIN executor_network_profile enp ON me.executor_id = enp.executor_id
-            LEFT JOIN executor_speedtest_profile esp ON me.executor_id = esp.executor_id
+            LEFT JOIN gpu_uuid_assignments gua ON me.executor_id = gua.executor_id AND gua.miner_id = me.miner_id
+            LEFT JOIN executor_hardware_profile ehp ON me.executor_id = ehp.executor_id AND me.miner_id = 'miner_' || ehp.miner_uid
+            LEFT JOIN executor_network_profile enp ON me.executor_id = enp.executor_id AND me.miner_id = 'miner_' || enp.miner_uid
+            LEFT JOIN executor_speedtest_profile esp ON me.executor_id = esp.executor_id AND me.miner_id = 'miner_' || esp.miner_uid
             WHERE r.id IS NULL
                 AND (me.status IS NULL OR me.status != 'offline')",
         );
@@ -1519,8 +1519,8 @@ impl SimplePersistence {
                 enp.region,
                 enp.country
              FROM miner_executors me
-             LEFT JOIN executor_hardware_profile ehp ON me.executor_id = ehp.executor_id
-             LEFT JOIN executor_network_profile enp ON me.executor_id = enp.executor_id
+             LEFT JOIN executor_hardware_profile ehp ON me.executor_id = ehp.executor_id AND me.miner_id = 'miner_' || ehp.miner_uid
+             LEFT JOIN executor_network_profile enp ON me.executor_id = enp.executor_id AND me.miner_id = 'miner_' || enp.miner_uid
              WHERE me.miner_id = ?",
         )
         .bind(miner_id)
@@ -1611,10 +1611,10 @@ impl SimplePersistence {
                 esp.upload_mbps,
                 esp.test_timestamp
              FROM miner_executors me
-             LEFT JOIN gpu_uuid_assignments gua ON me.executor_id = gua.executor_id
-             LEFT JOIN executor_hardware_profile ehp ON me.executor_id = ehp.executor_id
-             LEFT JOIN executor_network_profile enp ON me.executor_id = enp.executor_id
-             LEFT JOIN executor_speedtest_profile esp ON me.executor_id = esp.executor_id
+             LEFT JOIN gpu_uuid_assignments gua ON me.executor_id = gua.executor_id AND gua.miner_id = me.miner_id
+             LEFT JOIN executor_hardware_profile ehp ON me.executor_id = ehp.executor_id AND me.miner_id = 'miner_' || ehp.miner_uid
+             LEFT JOIN executor_network_profile enp ON me.executor_id = enp.executor_id AND me.miner_id = 'miner_' || enp.miner_uid
+             LEFT JOIN executor_speedtest_profile esp ON me.executor_id = esp.executor_id AND me.miner_id = 'miner_' || esp.miner_uid
              WHERE me.executor_id = ? AND me.miner_id = ?
              GROUP BY me.executor_id, me.location,
                       ehp.cpu_model, ehp.cpu_cores, ehp.ram_gb,

--- a/crates/basilica-validator/src/persistence/simple_persistence.rs
+++ b/crates/basilica-validator/src/persistence/simple_persistence.rs
@@ -698,6 +698,7 @@ impl SimplePersistence {
             FROM miner_executors me
             JOIN miners m ON me.miner_id = m.id
             LEFT JOIN rentals r ON me.executor_id = r.executor_id
+                AND r.miner_id = me.miner_id
                 AND r.state IN ('Active', 'Provisioning', 'active', 'provisioning')
             LEFT JOIN gpu_uuid_assignments gua ON me.executor_id = gua.executor_id AND gua.miner_id = me.miner_id
             LEFT JOIN executor_hardware_profile ehp ON me.executor_id = ehp.executor_id AND me.miner_id = 'miner_' || ehp.miner_uid


### PR DESCRIPTION
## Summary
Fix duplicate rows in executor queries by adding miner_id conditions to table joins.

## Problem
When executors were associated with multiple miners, the LEFT JOIN operations would create duplicate rows in the result set, causing incorrect data aggregation and display issues.

## Solution
Added miner_id conditions to all LEFT JOIN clauses to ensure proper 1:1 relationships:
- For gpu_uuid_assignments: Direct miner_id match
- For profile tables: Match using 'miner_' || miner_uid pattern

## Affected Queries
- get_available_executors() - Query for available executors
- get_executor_by_miner() - Query for executors by specific miner
- get_executor_details() - Query for detailed executor information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Hardware, GPU, network, and speedtest profiles are now correctly tied to the selected miner, preventing cross-miner data mix-ups.
  - Available Executors, Miner Executors, and Executor Details views now display details that reliably match the chosen miner.
  - Improves consistency and trustworthiness of displayed resource capabilities and performance metrics across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->